### PR TITLE
Finishing adding NetBSD support

### DIFF
--- a/HPL2/core/include/impl/LowLevelGraphicsSDL.h
+++ b/HPL2/core/include/impl/LowLevelGraphicsSDL.h
@@ -37,7 +37,7 @@
 #endif
 
 // Include these AFTER SDL
-#if defined(__linux__) || defined(__FreeBSD__) || defined (__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined (__OpenBSD__) || defined(__NetBSD__)
 #include <GL/glx.h>
 #endif
 

--- a/HPL2/core/sources/impl/PBuffer.cpp
+++ b/HPL2/core/sources/impl/PBuffer.cpp
@@ -174,7 +174,7 @@ namespace hpl {
 		mpLowLevelGraphics->ClearFrameBuffer(eClearFrameBufferFlag_Color);
 
 		wglMakeCurrent(OldHDC,OldGLRC);
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 		return false;
 #endif
 

--- a/HPL2/core/sources/impl/ThreadSDL.cpp
+++ b/HPL2/core/sources/impl/ThreadSDL.cpp
@@ -91,7 +91,7 @@ namespace hpl {
 #else
 		/** investigate further on other linux distros and mac os x
 		 * As right now Priority range seems to be 0 .. 0 in linux */
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 		struct sched_param param;
 		param.sched_priority = TranslateEnginePrio(aPrio);
 		int ret = pthread_setschedparam(SDL_GetThreadID(mpThreadHandle),SCHED_OTHER,&param);

--- a/HPL2/core/sources/resources/GpuShaderManager.cpp
+++ b/HPL2/core/sources/resources/GpuShaderManager.cpp
@@ -62,6 +62,8 @@ namespace hpl {
         mpPreprocessParser->GetEnvVarContainer()->Add("OS_FreeBSD");
 #elif defined(__OpenBSD__)
         mpPreprocessParser->GetEnvVarContainer()->Add("OS_OpenBSD");
+#elif defined(__NetBSD__)
+        mpPreprocessParser->GetEnvVarContainer()->Add("OS_NetBSD");
 #endif
 	}
 

--- a/HPL2/dependencies/AngelScript/sources/as_config.h
+++ b/HPL2/dependencies/AngelScript/sources/as_config.h
@@ -468,7 +468,7 @@
 	#define STDCALL
 
 	// Linux specific
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 		#define THISCALL_RETURN_SIMPLE_IN_MEMORY
 		#define CDECL_RETURN_SIMPLE_IN_MEMORY
 		#define STDCALL_RETURN_SIMPLE_IN_MEMORY
@@ -587,7 +587,7 @@
         #define AS_WINDOWS_THREADS
 
 	// Linux
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 		#if defined(i386) && !defined(__LP64__)
 			#define THISCALL_RETURN_SIMPLE_IN_MEMORY
 			#define CDECL_RETURN_SIMPLE_IN_MEMORY
@@ -612,7 +612,7 @@
 		#endif
 
 	// Free BSD
-	#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+	#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 		#define AS_BSD
 		#if defined(i386) && !defined(__LP64__)
 			#define AS_X86

--- a/amnesia/src/game/LuxBasePersonal.h
+++ b/amnesia/src/game/LuxBasePersonal.h
@@ -32,7 +32,7 @@
 #define PERSONAL_RELATIVEROOT _W("")
 #define PERSONAL_RELATIVEPIECES
 #define PERSONAL_RELATIVEPIECES_COUNT 0
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #define PERSONAL_RELATIVEROOT _W(".frictionalgames/")
 #define PERSONAL_RELATIVEPIECES _W(".frictionalgames"),
 #define PERSONAL_RELATIVEPIECES_COUNT 1


### PR DESCRIPTION
My previous patch #5 allowed the code to compile but I didn't have the game files to properly test it. Well, I finally acquired the game and I discovered that I didn't fill in some important gaps, whoops. Definitely the most critical part that was missing NetBSD support was in AngelScript.

Now it's been actually tested on NetBSD/amd64 9.3, works for me pretty well.